### PR TITLE
Breakout MyQ interactions into its own class and add support for a MyQ Lamp module

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This code adapts [David Pfeffer's](https://github.com/pfeffed) unofficial [Chamb
 2. Replace `<MYQ_LOGIN_USERNAME>` and `<MYQ_LOGIN_PASSWORD>` in `main.py` with the username and password you created at Chamberlain, and substitute `amzn1.echo-sdk-ams.app.<your-alexa-skills-id>` with the ID of the ASK skill you created. The `APP_ID` should remain the same, it is Chamberlain specific and not specific to your MyQ account.
 3. Create a zip file for Lambda with the following command  (you'll need it later in step 6):
 
-        zip -r lambda-upload.zip main.py requests requests-2.9.1.dist-info
+        zip -r lambda-upload.zip main.py myq.py requests requests-2.9.1.dist-info
 
 4. Create a new [AWS Lambda](https://console.aws.amazon.com/lambda/home?region=us-east-1) function in the _us-east-1_ region. At "Select a Blueprint," press the "Next" button to skip.
 5. For the "Configure Triggers" page, click in the dotted box to show the triggers options, and select "Alexa Skills Kit." Click next to continue.

--- a/StepByStepInstructions
+++ b/StepByStepInstructions
@@ -77,9 +77,9 @@
                     
     c.  Save your changes.
                     
-8.  Create a zip file named "lambda-upload.zip" containing the edited "main.py" file along with 
-    the entire contents of folders "requests" and "requests-2.9.1.dist-info" while keeping the 
-    folder structures in tact.  You will be needing this zip file in step 11.c
+8.  Create a zip file named "lambda-upload.zip" containing the edited "main.py" file, the "myq.py" file,
+    the "requests" folder and the "requests-2.9.1.dist-info" folder. Be sure to keep the folder structures
+    in tact.  You will be needing this zip file in step 11.c
 9.  Create a free/Basic Amazon webservice (AWS) account via url "aws.amazon.com"
 10. On the upper right corner of the AWS main page, just beside your AWS account name,
     shows a location that you need click on and select "US East (N. Virginia)"

--- a/myq.py
+++ b/myq.py
@@ -18,8 +18,8 @@ class MyQ:
     myq_userid                  = ""
     myq_security_token          = ""
     myq_cached_login_response   = ""
-    myq_device_id               = ""
-    myq_lamp_device_id          = ""
+    myq_device_id               = False
+    myq_lamp_device_id          = False
 
     def __init__(self, username, password):
         self.username = username
@@ -134,9 +134,9 @@ class MyQ:
         devices = self.get_devices()
         for dev in devices:
             print("Device => " + dev["MyQDeviceTypeName"])
-            if dev["MyQDeviceTypeName"] in ["VGDO", "GarageDoorOpener", "Garage Door Opener WGDO"]:
+            if (not self.myq_device_id) and dev["MyQDeviceTypeName"] in ["VGDO", "GarageDoorOpener", "Garage Door Opener WGDO"]:
                 self.myq_device_id = str(dev["MyQDeviceId"])
-            elif dev["MyQDeviceTypeName"] == "LampModule":
+            elif (not self.myq_lamp_device_id) and dev["MyQDeviceTypeName"] == "LampModule":
                 self.myq_lamp_device_id = str(dev["MyQDeviceId"])
                 
     def check_door_state(self):

--- a/myq.py
+++ b/myq.py
@@ -1,0 +1,156 @@
+import requests
+import os
+import json
+import time
+
+class MyQ:
+
+    APP_ID = "Vj8pQggXLhLy0WHahglCD4N1nAkkXQtGYpq2HrHD7H1nvmbT55KqtN6RSF4ILB/i"
+    LOCALE = "en"
+    HOST_URI = "myqexternal.myqdevice.com"
+    LOGIN_ENDPOINT = "api/v4/User/Validate"
+    DEVICE_LIST_ENDPOINT = "api/v4/UserDeviceDetails/Get"
+    DEVICE_SET_ENDPOINT = "api/v4/DeviceAttribute/PutDeviceAttribute"
+
+    username = "<MYQ_LOGIN_USERNAME>"
+    password = "<MYQ_LOGIN_PASSWORD>"
+
+    myq_userid                  = ""
+    myq_security_token          = ""
+    myq_cached_login_response   = ""
+    myq_device_id               = ""
+    myq_lamp_device_id          = ""
+
+    def __init__(self, username, password):
+        self.username = username
+        self.password = password
+    
+    def open(self):
+        self.change_door_state("open")
+    
+    def close(self):
+        self.change_door_state("close")
+        
+    def lamp_on(self):
+        self.change_lamp_state("on")
+    
+    def lamp_off(self):
+        self.change_lamp_state("off")
+    
+    def status(self):
+        state = self.check_door_state()
+    
+        if state == "1":
+            return "open"
+        elif state == "2":
+            return "closed"
+        elif state == "3":
+            return "stopped"
+        elif state == "4":
+            return "opening"
+        elif state == "5":
+            return "closing"
+        elif state == "8":
+            return "moving"
+        elif state == "9":
+            return "open"
+        else:
+            return str(state) + ", an unknown state for the door."
+    
+    def lamp_status(self):
+        state = self.check_lamp_state()
+        if state == "0":
+            return "off"
+        elif state == "1":
+            return "on"
+        else:
+            return "unknown"
+    
+    
+    def login(self):
+        params = {
+            'username': self.username,
+            'password': self.password
+        }
+        login = requests.post(
+                'https://{host_uri}/{login_endpoint}'.format(
+                    host_uri=self.HOST_URI,
+                    login_endpoint=self.LOGIN_ENDPOINT),
+                    json=params,
+                    headers={
+                        'MyQApplicationId': self.APP_ID
+                    }
+            )
+    
+        auth = login.json()
+        self.myq_security_token = auth['SecurityToken']
+        return True
+    
+    def change_device_state(self, payload):
+        device_action = requests.put(
+            'https://{host_uri}/{device_set_endpoint}'.format(
+                host_uri=self.HOST_URI,
+                device_set_endpoint=self.DEVICE_SET_ENDPOINT),
+                data=payload,
+                headers={
+                    'MyQApplicationId': self.APP_ID,
+                    'SecurityToken': self.myq_security_token
+                }
+        )
+        return device_action.status_code == 200
+    
+    def change_lamp_state(self, command):
+        newstate = 1 if command.lower() == "on" else 0
+        payload = {
+            "attributeName": "desiredlightstate",
+            "myQDeviceId": self.myq_lamp_device_id,
+            "AttributeValue": newstate
+        }
+        return self.change_device_state(payload)
+    
+    def change_door_state(self, command):
+        open_close_state = 1 if command.lower() == "open" else 0
+    
+        payload = {
+            'attributeName': 'desireddoorstate',
+            'myQDeviceId': self.myq_device_id,
+            'AttributeValue': open_close_state,
+        }
+        return self.change_device_state(payload)
+    
+    def get_devices(self):
+        devices = requests.get(
+            'https://{host_uri}/{device_list_endpoint}'.format(
+                host_uri=self.HOST_URI,
+                device_list_endpoint=self.DEVICE_LIST_ENDPOINT),
+                headers={
+                    'MyQApplicationId': self.APP_ID,
+                    'SecurityToken': self.myq_security_token
+                }
+        )
+        return devices.json()['Devices']
+    
+    def get_device_id(self):
+        devices = self.get_devices()
+        for dev in devices:
+            print("Device => " + dev["MyQDeviceTypeName"])
+            if dev["MyQDeviceTypeName"] in ["VGDO", "GarageDoorOpener", "Garage Door Opener WGDO"]:
+                self.myq_device_id = str(dev["MyQDeviceId"])
+            elif dev["MyQDeviceTypeName"] == "LampModule":
+                self.myq_lamp_device_id = str(dev["MyQDeviceId"])
+                
+    def check_door_state(self):
+        return self.check_device_state(self.myq_device_id, "doorstate")
+    
+    def check_lamp_state(self):
+        return self.check_device_state(self.myq_lamp_device_id, "lightstate")
+        
+    def check_device_state(self, device_id, state_name):
+        devices = self.get_devices()
+        for dev in devices:
+            if str(dev["MyQDeviceId"]) == str(device_id):
+                for attribute in dev["Attributes"]:
+                    if attribute["AttributeDisplayName"] == state_name:
+                        door_state = attribute['Value']
+        
+        return door_state


### PR DESCRIPTION
I use this Alexa app along side some web hooks (for IFTT triggers.) By breaking out the MyQ interactions into its own file people like me can use the same file to support both the Alexa app and the web hooks. This means that we wont have to manually update the api changes.

I also added support for the MyQ Lamp module (http://www.chamberlain.com/smartphone-control-products/lighting-controls/myq-remote-lamp-control) Currently, lamp support is just in the class file not in the Alexa intents, but it could easily be added there. 